### PR TITLE
lock files for interchain transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
+ "cosmrs",
  "cosmwasm-std",
  "dotenv",
  "ebtc_maxbtc_types",

--- a/packages/src/utils/mod.rs
+++ b/packages/src/utils/mod.rs
@@ -1,4 +1,16 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::str::FromStr;
+use alloy::eips::BlockId;
+use alloy::eips::BlockNumberOrTag::Finalized;
+use alloy::network::primitives::BlockTransactionsKind;
+use alloy::providers::Provider;
+use cosmwasm_std::Uint128;
+use log::info;
+use tokio::time::sleep;
 use valence_domain_clients::coprocessor::base_client::{Base64, Proof};
+use valence_domain_clients::evm::base_client::CustomProvider;
 
 pub mod crypto_provider;
 pub mod logging;
@@ -15,4 +27,50 @@ pub fn decode(a: Proof) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     let inputs = Base64::decode(&a.inputs)?;
 
     Ok((proof, inputs))
+}
+
+pub async fn wait_for_block_to_finalize(block_number: u64, eth_rp: &CustomProvider) -> Result<(), Box<dyn Error + Send + Sync>> {
+    loop {
+        info!("Waiting for block {} to be finalized...", block_number);
+        if let Some(block) = eth_rp.get_block(BlockId::Number(Finalized), BlockTransactionsKind::Hashes).await? {
+            if block.header.number >= block_number {
+                return Ok(());
+            }
+        }
+        sleep(std::time::Duration::from_secs(10)).await;
+    }
+}
+
+
+pub async fn lock_transfer(label:&str, name: &str, amount: u128) -> anyhow::Result<()> {
+    info!("locking transfer for {} {}", label, name);
+    let mut file = File::create(format!("{}_{}_transfer", label, name))?;
+    file.write_all(amount.to_string().as_bytes())
+        .expect(
+            "failed to write to file",
+        );
+    Ok(())
+}
+
+pub async fn unlock_transfer(label:&str, name: &str) -> anyhow::Result<()> {
+    info!("unlocking transfer for {} {}", label, name);
+    std::fs::remove_file(format!("{}_{}_transfer", label, name))?;
+    Ok(())
+}
+
+pub async fn check_transfer_lock(label:&str, name: &str) -> Option<Uint128> {
+    info!("checking transfer lock for {} {}", label, name);
+    if let Ok(mut file) = File::open(format!("{}_{}_transfer", label, name)) {
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)
+            .expect(
+                "failed to read file",
+            );
+
+        let amount_to_wait_for = Uint128::from_str(&buf.strip_suffix("\n").unwrap()).unwrap();
+
+        return Some(amount_to_wait_for);
+    }
+
+    None
 }

--- a/packages/src/utils/mod.rs
+++ b/packages/src/utils/mod.rs
@@ -34,6 +34,7 @@ pub async fn wait_for_block_to_finalize(block_number: u64, eth_rp: &CustomProvid
         info!("Waiting for block {} to be finalized...", block_number);
         if let Some(block) = eth_rp.get_block(BlockId::Number(Finalized), BlockTransactionsKind::Hashes).await? {
             if block.header.number >= block_number {
+                sleep(std::time::Duration::from_secs(60)).await;
                 return Ok(());
             }
         }

--- a/strategies/ebtc_maxbtc/strategist/Cargo.toml
+++ b/strategies/ebtc_maxbtc/strategist/Cargo.toml
@@ -31,3 +31,4 @@ valence-lending-utils              = { workspace = true }
 mmvault                            = { workspace = true }
 serde_json                         = { workspace = true }
 tokio                              = { workspace = true }
+cosmrs = { workspace = true }

--- a/strategies/ebtc_maxbtc/strategist/src/phases/deposit.rs
+++ b/strategies/ebtc_maxbtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/ebtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/ebtc_maxbtc/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
@@ -79,7 +79,7 @@ impl ValenceWorker for Strategy {
                 .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
                 .await?;
             info!("Vault unpaused");
-            
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.

--- a/strategies/ebtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/ebtc_maxbtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/ebtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/ebtc_maxbtc/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+            
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/maxbtc_mint/strategist/src/phases/deposit.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/deposit.rs
@@ -3,7 +3,10 @@ use alloy::{
     providers::Provider,
 };
 
-use cosmwasm_std::to_json_binary;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::str::FromStr;
+use cosmwasm_std::{to_json_binary, Uint128};
 use log::{info, warn};
 use packages::{
     labels::{ICA_TRANSFER_LABEL, MAXBTC_ISSUE_LABEL},
@@ -18,7 +21,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 impl Strategy {
@@ -44,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -193,6 +230,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -218,6 +257,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -284,6 +326,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -297,6 +341,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/maxbtc_mint/strategist/src/strategist.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategist.rs
@@ -48,7 +48,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
                 .duration_since(std::time::SystemTime::UNIX_EPOCH)?
                 .as_secs()
         {
@@ -83,7 +83,7 @@ impl ValenceWorker for Strategy {
                 .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
                 .await?;
             info!("Vault unpaused");
-            
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.

--- a/strategies/maxbtc_mint/strategist/src/strategist.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategist.rs
@@ -1,14 +1,20 @@
-use std::error::Error;
-
+use crate::strategy_config::Strategy;
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
+use packages::types::sol_types::OneWayVault;
+use std::error::Error;
+use alloy::eips::{BlockId, BlockNumberOrTag};
+use alloy::eips::BlockNumberOrTag::Finalized;
+use alloy::network::primitives::BlockTransactionsKind;
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
 use valence_strategist_utils::worker::ValenceWorker;
-
-use crate::strategy_config::Strategy;
+use tokio::time::sleep;
+use packages::utils::wait_for_block_to_finalize;
 
 // implement the ValenceWorker trait for the Strategy struct.
 // This trait defines the main loop of the strategy and inherits
@@ -27,21 +33,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+                .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/maxbtc_mint/strategist/src/strategist.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategist.rs
@@ -76,18 +76,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+            
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/solvbtc_maxbtc/strategist/src/phases/deposit.rs
+++ b/strategies/solvbtc_maxbtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {

--- a/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/solvbtc_maxbtc/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/unibtc_maxbtc/strategist/src/phases/deposit.rs
+++ b/strategies/unibtc_maxbtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/unibtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/unibtc_maxbtc/strategist/src/strategist.rs
@@ -51,11 +51,11 @@ impl ValenceWorker for Strategy {
             info!("Rate update required");
 
             info!("Pausing vault...");
-            let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
+            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            // eth_rp
+            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+            //     .await?;
             info!("Vault paused");
 
             let last_block_after_pause = self.eth_client.latest_block_height().await?;
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/unibtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/unibtc_maxbtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/unibtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/unibtc_maxbtc/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {

--- a/strategies/unibtc_maxbtc/strategist/src/strategist.rs
+++ b/strategies/unibtc_maxbtc/strategist/src/strategist.rs
@@ -51,11 +51,11 @@ impl ValenceWorker for Strategy {
             info!("Rate update required");
 
             info!("Pausing vault...");
-            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            // eth_rp
-            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-            //     .await?;
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
             info!("Vault paused");
 
             let last_block_after_pause = self.eth_client.latest_block_height().await?;

--- a/strategies/wbtc_ebtc/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc_ebtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/wbtc_ebtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_ebtc/strategist/src/strategist.rs
@@ -50,27 +50,27 @@ impl ValenceWorker for Strategy {
         {
             info!("Rate update required");
 
-            // info!("Pausing vault...");
-            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            // eth_rp
-            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-            //     .await?;
-            // info!("Vault paused");
-            //
-            // let last_block_after_pause = self.eth_client.latest_block_height().await?;
-            //
-            // wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
-            //
-            // // first we carry out the deposit flow
-            // self.deposit(&eth_rp).await?;
-            //
-            // // after deposit flow is complete, we process the new obligations
-            // self.register_withdraw_obligations().await?;
-            //
-            // // with new obligations registered into the clearing queue, we
-            // // carry out the settlements
-            // self.settlement().await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
+
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
 
             info!("Unpausing vault...");
             let unpause_request = one_way_vault_contract.unpause().into_transaction_request();

--- a/strategies/wbtc_ebtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_ebtc/strategist/src/strategist.rs
@@ -44,33 +44,33 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
             info!("Rate update required");
 
-            info!("Pausing vault...");
-            let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault paused");
-
-            let last_block_after_pause = self.eth_client.latest_block_height().await?;
-
-            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
-
-            // first we carry out the deposit flow
-            self.deposit(&eth_rp).await?;
-
-            // after deposit flow is complete, we process the new obligations
-            self.register_withdraw_obligations().await?;
-
-            // with new obligations registered into the clearing queue, we
-            // carry out the settlements
-            self.settlement().await?;
+            // info!("Pausing vault...");
+            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            // eth_rp
+            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+            //     .await?;
+            // info!("Vault paused");
+            //
+            // let last_block_after_pause = self.eth_client.latest_block_height().await?;
+            //
+            // wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+            //
+            // // first we carry out the deposit flow
+            // self.deposit(&eth_rp).await?;
+            //
+            // // after deposit flow is complete, we process the new obligations
+            // self.register_withdraw_obligations().await?;
+            //
+            // // with new obligations registered into the clearing queue, we
+            // // carry out the settlements
+            // self.settlement().await?;
 
             info!("Unpausing vault...");
             let unpause_request = one_way_vault_contract.unpause().into_transaction_request();

--- a/strategies/wbtc_ebtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_ebtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/wbtc_ebtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_ebtc/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/wbtc_lend/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc_lend/strategist/src/phases/deposit.rs
@@ -32,6 +32,7 @@ use valence_domain_clients::{
 };
 use valence_domain_clients::coprocessor::base_client::CoprocessorBaseClient;
 use valence_library_utils::OptionUpdate;
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 
 impl Strategy {
     pub async fn deposit(&mut self, eth_rp: &CustomProvider) -> anyhow::Result<()> {
@@ -50,6 +51,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -135,6 +170,10 @@ impl Strategy {
             }
         };
 
+        let post_fee_amount_out_u128 = utils::skip::get_amount_out(&skip_api_response)?;
+        info!(target: DEPOSIT_PHASE, "post_fee_amount_out_u128 = {post_fee_amount_out_u128:?}" );
+
+
         // format the response in format expected by the coprocessor and post it
         // there for proof
         let coprocessor_input = json!({"skip_response": skip_api_response});
@@ -170,6 +209,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // block execution until the funds arrive to the Cosmos Hub ICA owned
         // by the Valence Interchain Account on Neutron.
         // we poll
@@ -192,6 +233,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -260,6 +304,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", gaia_ica_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -274,6 +320,8 @@ impl Strategy {
             )
             .await?;
 
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+        
         Ok(())
     }
 }

--- a/strategies/wbtc_lend/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
@@ -79,7 +79,7 @@ impl ValenceWorker for Strategy {
                 .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
                 .await?;
             info!("Vault unpaused");
-            
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.

--- a/strategies/wbtc_lend/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/wbtc_lend/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+            
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/wbtc_lend_mars/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc_lend_mars/strategist/src/phases/deposit.rs
@@ -32,6 +32,7 @@ use valence_domain_clients::{
 };
 use valence_domain_clients::coprocessor::base_client::CoprocessorBaseClient;
 use valence_library_utils::OptionUpdate;
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 
 impl Strategy {
     pub async fn deposit(&mut self, eth_rp: &CustomProvider) -> anyhow::Result<()> {
@@ -50,6 +51,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -135,6 +170,9 @@ impl Strategy {
             }
         };
 
+        let post_fee_amount_out_u128 = utils::skip::get_amount_out(&skip_api_response)?;
+        info!(target: DEPOSIT_PHASE, "post_fee_amount_out_u128 = {post_fee_amount_out_u128:?}" );
+
         // format the response in format expected by the coprocessor and post it
         // there for proof
         let coprocessor_input = json!({"skip_response": skip_api_response});
@@ -170,6 +208,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // block execution until the funds arrive to the Cosmos Hub ICA owned
         // by the Valence Interchain Account on Neutron.
         // we poll
@@ -192,6 +232,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -260,6 +303,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", gaia_ica_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -273,6 +318,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/wbtc_lend_mars/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend_mars/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
@@ -79,7 +79,7 @@ impl ValenceWorker for Strategy {
                 .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
                 .await?;
             info!("Vault unpaused");
-            
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.

--- a/strategies/wbtc_lend_mars/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend_mars/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/wbtc_lend_mars/strategist/src/strategist.rs
+++ b/strategies/wbtc_lend_mars/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+            
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/wbtc_solvbtc/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc_solvbtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/wbtc_solvbtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_solvbtc/strategist/src/strategist.rs
@@ -44,7 +44,7 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
@@ -79,7 +79,7 @@ impl ValenceWorker for Strategy {
                 .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
                 .await?;
             info!("Vault unpaused");
-            
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.

--- a/strategies/wbtc_solvbtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_solvbtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/wbtc_solvbtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_solvbtc/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+            
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/wbtc_unibtc/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc_unibtc/strategist/src/phases/deposit.rs
@@ -18,7 +18,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-
+use packages::utils::{check_transfer_lock, lock_transfer, unlock_transfer};
 use crate::strategy_config::Strategy;
 
 /// minimum Valence account balance to perform a split
@@ -47,6 +47,40 @@ impl Strategy {
                 .await?
                 ._0;
             info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "eth_gaia").await {
+                // block execution until the funds arrive to the Cosmos Hub ICA owned
+                // by the Valence Interchain Account on Neutron.
+                // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+                // IBC Eureka routing time of 15min
+                self.gaia_client
+                    .poll_until_expected_balance(
+                        &self.cfg.gaia.ica_address,
+                        &self.cfg.gaia.deposit_denom,
+                        amount_to_wait_for.u128(),
+                        15,  // every 15 sec
+                        100, // for 100 times
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(),"eth_gaia").await?;
+            }
+
+            if let Some(amount_to_wait_for) = check_transfer_lock(self.label.as_str(), "gaia_neutron").await {
+                // block execution until funds arrive to the Neutron program deposit
+                // account
+                self.neutron_client
+                    .poll_until_expected_balance(
+                        &self.cfg.neutron.accounts.deposit,
+                        &self.cfg.neutron.denoms.deposit_token,
+                        amount_to_wait_for.u128(),
+                        5,
+                        30,
+                    )
+                    .await?;
+
+                unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
+            }
 
             // validate that the deposit account balance exceeds the eureka routing
             // threshold amount
@@ -219,6 +253,8 @@ impl Strategy {
             .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
             .await?;
 
+        lock_transfer(self.label.as_str(), "eth_gaia", post_fee_amount_out_u128).await?;
+
         // transfer can be considered complete when the current ica balance increases
         // by the expected post_fee ibc eureka transfer amount out
         let pre_routing_gaia_ica_bal = self
@@ -244,6 +280,9 @@ impl Strategy {
                 100, // for 100 times
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "eth_gaia").await?;
+
         Ok(())
     }
 
@@ -310,6 +349,8 @@ impl Strategy {
         info!(target: DEPOSIT_PHASE, "tick: update & transfer");
         valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
 
+        lock_transfer(self.label.as_str(), "gaia_neutron", neutron_deposit_acc_expected_bal).await?;
+
         info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
 
         // block execution until funds arrive to the Neutron program deposit
@@ -323,6 +364,8 @@ impl Strategy {
                 30,
             )
             .await?;
+
+        unlock_transfer(self.label.as_str(), "gaia_neutron").await?;
 
         Ok(())
     }

--- a/strategies/wbtc_unibtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_unibtc/strategist/src/strategist.rs
@@ -50,27 +50,27 @@ impl ValenceWorker for Strategy {
         {
             info!("Rate update required");
 
-            // info!("Pausing vault...");
-            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            // eth_rp
-            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-            //     .await?;
-            // info!("Vault paused");
-            //
-            // let last_block_after_pause = self.eth_client.latest_block_height().await?;
-            //
-            // wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
+
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
 
             // first we carry out the deposit flow
-            // self.deposit(&eth_rp).await?;
+            self.deposit(&eth_rp).await?;
 
             // after deposit flow is complete, we process the new obligations
-            // self.register_withdraw_obligations().await?;
+            self.register_withdraw_obligations().await?;
 
             // with new obligations registered into the clearing queue, we
             // carry out the settlements
-            // self.settlement().await?;
+            self.settlement().await?;
 
             info!("Unpausing vault...");
             let unpause_request = one_way_vault_contract.unpause().into_transaction_request();

--- a/strategies/wbtc_unibtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_unibtc/strategist/src/strategist.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
-
+use alloy::providers::Provider;
 use async_trait::async_trait;
 use log::info;
 use packages::phases::VALENCE_WORKER;
 use valence_domain_clients::evm::{
     base_client::CustomProvider, request_provider_client::RequestProviderClient,
 };
+use valence_domain_clients::evm::base_client::EvmBaseClient;
 use valence_strategist_utils::worker::ValenceWorker;
-
+use packages::types::sol_types::OneWayVault;
+use packages::utils::wait_for_block_to_finalize;
 use crate::strategy_config::Strategy;
 
 // implement the ValenceWorker trait for the Strategy struct.
@@ -27,21 +29,73 @@ impl ValenceWorker for Strategy {
 
         let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
 
-        // first we carry out the deposit flow
-        self.deposit(&eth_rp).await?;
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
 
-        // after deposit flow is complete, we process the new obligations
-        self.register_withdraw_obligations().await?;
+        let min_rate_update_delay = self
+            .eth_client
+            .query(one_way_vault_contract.config())
+            .await?
+            .minRateUpdateDelay;
+        let last_rr_update_time = self
+            .eth_client
+            .query(one_way_vault_contract.lastRateUpdateTimestamp())
+            .await?
+            ._0;
 
-        // with new obligations registered into the clearing queue, we
-        // carry out the settlements
-        self.settlement().await?;
+        if last_rr_update_time + min_rate_update_delay
+            > std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs()
+        {
+            info!("Rate update required");
 
-        // having processed all new exit requests after the deposit flow,
-        // the epoch is ready to be concluded.
-        // we perform the final accounting flow and post vault update.
-        self.update(&eth_rp).await?;
+            info!("Pausing vault...");
+            let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault paused");
 
+            let last_block_after_pause = self.eth_client.latest_block_height().await?;
+
+            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+
+            // having processed all new exit requests after the deposit flow,
+            // the epoch is ready to be concluded.
+            // we perform the final accounting flow and post vault update.
+            self.update(&eth_rp).await?;
+
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+        } else {
+            info!("Rate update not required");
+            // first we carry out the deposit flow
+            self.deposit(&eth_rp).await?;
+
+            // after deposit flow is complete, we process the new obligations
+            self.register_withdraw_obligations().await?;
+
+            // with new obligations registered into the clearing queue, we
+            // carry out the settlements
+            self.settlement().await?;
+        }
         Ok(())
     }
 }

--- a/strategies/wbtc_unibtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_unibtc/strategist/src/strategist.rs
@@ -72,18 +72,18 @@ impl ValenceWorker for Strategy {
             // carry out the settlements
             self.settlement().await?;
 
+            info!("Unpausing vault...");
+            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
+            let unpause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
+            eth_rp
+                .get_transaction_receipt(unpause_vault_exec_response.transaction_hash)
+                .await?;
+            info!("Vault unpaused");
+
             // having processed all new exit requests after the deposit flow,
             // the epoch is ready to be concluded.
             // we perform the final accounting flow and post vault update.
             self.update(&eth_rp).await?;
-
-            info!("Unpausing vault...");
-            let unpause_request = one_way_vault_contract.unpause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(unpause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault unpaused");
         } else {
             info!("Rate update not required");
             // first we carry out the deposit flow

--- a/strategies/wbtc_unibtc/strategist/src/strategist.rs
+++ b/strategies/wbtc_unibtc/strategist/src/strategist.rs
@@ -44,33 +44,33 @@ impl ValenceWorker for Strategy {
             ._0;
 
         if last_rr_update_time + min_rate_update_delay
-            > std::time::SystemTime::now()
+            <= std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)?
             .as_secs()
         {
             info!("Rate update required");
 
-            info!("Pausing vault...");
-            let pause_request = one_way_vault_contract.pause().into_transaction_request();
-            let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
-            eth_rp
-                .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
-                .await?;
-            info!("Vault paused");
-
-            let last_block_after_pause = self.eth_client.latest_block_height().await?;
-
-            wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
+            // info!("Pausing vault...");
+            // let pause_request = one_way_vault_contract.pause().into_transaction_request();
+            // let pause_vault_exec_response = self.eth_client.sign_and_send(pause_request).await?;
+            // eth_rp
+            //     .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+            //     .await?;
+            // info!("Vault paused");
+            //
+            // let last_block_after_pause = self.eth_client.latest_block_height().await?;
+            //
+            // wait_for_block_to_finalize(last_block_after_pause, &eth_rp).await?;
 
             // first we carry out the deposit flow
-            self.deposit(&eth_rp).await?;
+            // self.deposit(&eth_rp).await?;
 
             // after deposit flow is complete, we process the new obligations
-            self.register_withdraw_obligations().await?;
+            // self.register_withdraw_obligations().await?;
 
             // with new obligations registered into the clearing queue, we
             // carry out the settlements
-            self.settlement().await?;
+            // self.settlement().await?;
 
             info!("Unpausing vault...");
             let unpause_request = one_way_vault_contract.unpause().into_transaction_request();


### PR DESCRIPTION
This PR:
* pauses vaults during RR update (and unpauses them after that);
* uses lock files to wait for interchain transfers to complete